### PR TITLE
Embed Spotify music previews into articles

### DIFF
--- a/backend/app/db/models/article.py
+++ b/backend/app/db/models/article.py
@@ -19,6 +19,7 @@ class ArticleDB(Base):
     article_type = Column(String, default="general", index=True)
     project_id = Column(Integer, ForeignKey("projects.id"), nullable=False)
     header_image_id = Column(Integer, ForeignKey("images.id"), nullable=True)
+    spotify_url = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/app/domain/models/article.py
+++ b/backend/app/domain/models/article.py
@@ -52,6 +52,7 @@ class Article:
     project_id: int
     id: Optional[int] = None
     header_image_id: Optional[int] = None
+    spotify_url: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 

--- a/backend/app/schemas/article.py
+++ b/backend/app/schemas/article.py
@@ -33,6 +33,7 @@ class ArticleBase(BaseModel):
     article_type: ArticleTypeEnum = Field(default=ArticleTypeEnum.GENERAL, description="Type of article")
     project_id: int = Field(..., description="ID of the project this article belongs to")
     header_image_id: Optional[int] = Field(None, description="ID of the header image")
+    spotify_url: Optional[str] = Field(None, description="Spotify track URL for mood/tone music")
 
 
 class ArticleCreate(ArticleBase):
@@ -46,6 +47,7 @@ class ArticleUpdate(BaseModel):
     content: Optional[ArticleContentSchema] = Field(None, description="Article content structure")
     article_type: Optional[ArticleTypeEnum] = Field(None, description="Type of article")
     header_image_id: Optional[int] = Field(None, description="ID of the header image")
+    spotify_url: Optional[str] = Field(None, description="Spotify track URL for mood/tone music")
 
 
 class Article(ArticleBase):

--- a/frontend/src/components/ArticleForm.tsx
+++ b/frontend/src/components/ArticleForm.tsx
@@ -26,6 +26,7 @@ export function ArticleForm({
     title: article?.title || '',
     article_type: article?.article_type || ArticleType.GENERAL,
     header_image_id: article?.header_image_id || null,
+    spotify_url: article?.spotify_url || '',
     content: {
       main_content: article?.content?.main_content || '',
       sidebar_content: article?.content?.sidebar_content || '',
@@ -43,7 +44,8 @@ export function ArticleForm({
     const submitData = {
       ...formData,
       project_id: article?.project_id || 1, // This should come from context/props
-      header_image_id: formData.header_image_id || undefined
+      header_image_id: formData.header_image_id || undefined,
+      spotify_url: formData.spotify_url || undefined
     };
     onSubmit(submitData);
   };
@@ -144,6 +146,21 @@ export function ArticleForm({
             )}
           </div>
         )}
+
+        {/* Spotify URL */}
+        <div className="space-y-2">
+          <Label htmlFor="spotify_url">Spotify URL (Mood Music)</Label>
+          <Input
+            id="spotify_url"
+            value={formData.spotify_url}
+            onChange={(e) => setFormData(prev => ({ ...prev, spotify_url: e.target.value }))}
+            placeholder="https://open.spotify.com/track/... or spotify:track:..."
+          />
+          <p className="text-sm text-muted-foreground">
+            Add a Spotify track URL to set the mood/tone for this article. 
+            Supports both web URLs and Spotify URIs.
+          </p>
+        </div>
 
         {/* Summary */}
         <div className="space-y-2">

--- a/frontend/src/components/DynamicArticleView.tsx
+++ b/frontend/src/components/DynamicArticleView.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { SettlementView } from './SettlementView';
 import { PersonView } from './PersonView';
+import { SpotifyEmbed } from './SpotifyEmbed';
 import { ArticleType, Article } from '../types/article';
 
 interface DynamicArticleViewProps {
@@ -57,6 +58,10 @@ function GenericArticleView({ article }: { article: Article }) {
         </div>
 
         <div className="space-y-4">
+          {article.spotify_url && (
+            <SpotifyEmbed spotifyUrl={article.spotify_url} />
+          )}
+
           {article.content?.sidebar_content && (
             <Card>
               <CardHeader>

--- a/frontend/src/components/PersonForm.tsx
+++ b/frontend/src/components/PersonForm.tsx
@@ -59,6 +59,7 @@ export function PersonForm({
 }: PersonFormProps) {
   const [formData, setFormData] = useState({
     title: article?.title || '',
+    spotify_url: article?.spotify_url || '',
     content: {
       main_content: article?.content?.main_content || '',
       sidebar_content: article?.content?.sidebar_content || '',
@@ -329,6 +330,20 @@ export function PersonForm({
               rows={3}
               placeholder="Brief summary of the character"
             />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="spotify_url">Spotify URL (Mood Music)</Label>
+            <Input
+              id="spotify_url"
+              value={formData.spotify_url}
+              onChange={(e) => setFormData(prev => ({ ...prev, spotify_url: e.target.value }))}
+              placeholder="https://open.spotify.com/track/... or spotify:track:..."
+            />
+            <p className="text-sm text-muted-foreground">
+              Add a Spotify track URL to set the mood/tone for this character. 
+              Supports both web URLs and Spotify URIs.
+            </p>
           </div>
         </CardContent>
       </Card>

--- a/frontend/src/components/PersonView.tsx
+++ b/frontend/src/components/PersonView.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { SpotifyEmbed } from './SpotifyEmbed';
 import { PersonArticle } from '../types/article';
 
 interface PersonViewProps {
@@ -292,6 +293,11 @@ export function PersonView({ article }: PersonViewProps) {
 
         {/* Sidebar */}
         <div className="space-y-4">
+          {/* Spotify Embed */}
+          {article.spotify_url && (
+            <SpotifyEmbed spotifyUrl={article.spotify_url} />
+          )}
+
           {/* Basic Details */}
           <Card>
             <CardHeader>

--- a/frontend/src/components/SettlementForm.tsx
+++ b/frontend/src/components/SettlementForm.tsx
@@ -50,6 +50,7 @@ export function SettlementForm({
 }: SettlementFormProps) {
   const [formData, setFormData] = useState({
     title: article?.title || '',
+    spotify_url: article?.spotify_url || '',
     content: {
       main_content: article?.content?.main_content || '',
       sidebar_content: article?.content?.sidebar_content || '',
@@ -209,6 +210,20 @@ export function SettlementForm({
               rows={3}
               placeholder="Brief summary of the settlement"
             />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="spotify_url">Spotify URL (Mood Music)</Label>
+            <Input
+              id="spotify_url"
+              value={formData.spotify_url}
+              onChange={(e) => setFormData(prev => ({ ...prev, spotify_url: e.target.value }))}
+              placeholder="https://open.spotify.com/track/... or spotify:track:..."
+            />
+            <p className="text-sm text-muted-foreground">
+              Add a Spotify track URL to set the mood/tone for this settlement. 
+              Supports both web URLs and Spotify URIs.
+            </p>
           </div>
         </CardContent>
       </Card>

--- a/frontend/src/components/SettlementView.tsx
+++ b/frontend/src/components/SettlementView.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { SpotifyEmbed } from './SpotifyEmbed';
 import { SettlementArticle } from '../types/article';
 
 interface SettlementViewProps {
@@ -198,6 +199,11 @@ export function SettlementView({ article }: SettlementViewProps) {
 
         {/* Sidebar */}
         <div className="space-y-4">
+          {/* Spotify Embed */}
+          {article.spotify_url && (
+            <SpotifyEmbed spotifyUrl={article.spotify_url} />
+          )}
+
           {/* Basic Details */}
           <Card>
             <CardHeader>

--- a/frontend/src/components/SpotifyEmbed.tsx
+++ b/frontend/src/components/SpotifyEmbed.tsx
@@ -1,0 +1,80 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface SpotifyEmbedProps {
+  spotifyUrl: string;
+  className?: string;
+}
+
+/**
+ * Converts various Spotify URL formats to the embed format
+ * Supports:
+ * - https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh
+ * - https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh?si=...
+ * - spotify:track:4iV5W9uYEdYUVa79Axb7Rh
+ */
+function getSpotifyEmbedUrl(url: string): string | null {
+  try {
+    // Handle spotify: protocol
+    if (url.startsWith('spotify:')) {
+      const parts = url.split(':');
+      if (parts.length >= 3 && parts[1] === 'track') {
+        return `https://open.spotify.com/embed/track/${parts[2]}`;
+      }
+      return null;
+    }
+
+    // Handle https://open.spotify.com URLs
+    if (url.includes('open.spotify.com')) {
+      const urlObj = new URL(url);
+      const pathParts = urlObj.pathname.split('/');
+      
+      if (pathParts.length >= 3 && pathParts[1] === 'track') {
+        const trackId = pathParts[2];
+        return `https://open.spotify.com/embed/track/${trackId}`;
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function SpotifyEmbed({ spotifyUrl, className }: SpotifyEmbedProps) {
+  const embedUrl = getSpotifyEmbedUrl(spotifyUrl);
+
+  if (!embedUrl) {
+    return (
+      <Card className={className}>
+        <CardHeader>
+          <CardTitle className="text-lg">Mood Music</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Invalid Spotify URL provided. Please check the URL format.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <CardTitle className="text-lg">Mood Music</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <iframe
+          src={embedUrl}
+          width="100%"
+          height="152"
+          frameBorder="0"
+          allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+          loading="lazy"
+          className="rounded-md"
+          title="Spotify player"
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/routes/articles.$articleId.tsx
+++ b/frontend/src/routes/articles.$articleId.tsx
@@ -48,6 +48,7 @@ const mockArticles: Record<string, Article> = {
       religions: ['Temple of Commerce', 'River Spirits'],
       festivals: ['Harvest Fair', 'River Festival', 'Bridge Day']
     },
+    spotify_url: 'https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh',
     created_at: '2024-01-15',
     updated_at: '2024-01-15',
   } as any,
@@ -131,6 +132,7 @@ const mockArticles: Record<string, Article> = {
       organizations: ['Silver Order', 'Ironhold Keep'],
       titles: ['Knight Commander', 'Defender of the Borderlands']
     },
+    spotify_url: 'https://open.spotify.com/track/7qiZfU4dY21yK3FjjafFpT',
     created_at: '2024-01-14',
     updated_at: '2024-01-16',
   } as any,
@@ -147,6 +149,7 @@ const mockArticles: Record<string, Article> = {
       tags: ['organization', 'politics', 'sci-fi'],
       metadata: {}
     },
+    spotify_url: 'https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp',
     created_at: '2024-01-10',
     updated_at: '2024-01-12',
   },

--- a/frontend/src/types/article.ts
+++ b/frontend/src/types/article.ts
@@ -47,6 +47,7 @@ export interface Article {
   project_id: number;
   header_image_id?: number | null;
   header_image?: Image | null;
+  spotify_url?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -57,6 +58,7 @@ export interface ArticleCreate {
   article_type: ArticleType;
   project_id: number;
   header_image_id?: number | null;
+  spotify_url?: string | null;
 }
 
 export interface ArticleUpdate {
@@ -64,6 +66,7 @@ export interface ArticleUpdate {
   content?: ArticleContent | null;
   article_type?: ArticleType;
   header_image_id?: number | null;
+  spotify_url?: string | null;
 }
 
 export interface ArticleSummary {


### PR DESCRIPTION
Add Spotify mood music embeds to articles to allow users to set a tone with a Spotify track.

---
<a href="https://cursor.com/background-agent?bcId=bc-835bf071-8f94-457c-87e4-2dd5cf327b81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-835bf071-8f94-457c-87e4-2dd5cf327b81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

